### PR TITLE
Fixed crash on startup

### DIFF
--- a/NotesEditerforD/Form1.cs
+++ b/NotesEditerforD/Form1.cs
@@ -385,7 +385,7 @@ namespace NotesEditerforD
             flowLayoutPanelMusicScore.Height = this.Height - 97;
             //*/
             flowLayoutPanelNotesButton.Height = this.Height - 72;
-            sRoot.panelResize(Width, Height);
+            sRoot?.panelResize(Width, Height);
         }
 
         private NotesButton activeNotesButton()

--- a/NotesEditerforD/NotesEditerforD.csproj
+++ b/NotesEditerforD/NotesEditerforD.csproj
@@ -62,7 +62,6 @@
     <Compile Include="MusicScore.cs">
       <SubType>Component</SubType>
     </Compile>
-    <Compile Include="MusicScore2.cs" />
     <Compile Include="Note2.cs" />
     <Compile Include="NotesButton.cs">
       <SubType>UserControl</SubType>


### PR DESCRIPTION
The program was crashing on my machine due to a NullReferenceException in the resize function.
It was also failing to compile due to the MusicScore2.cs file not existing.